### PR TITLE
feat(webdav): 通过环境变量支持自定义 WebDAV 端点

### DIFF
--- a/app/api/webdav/[...path]/route.ts
+++ b/app/api/webdav/[...path]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { STORAGE_KEY, internalAllowedWebDavEndpoints } from "../../../constant";
+import { STORAGE_KEY, allowedWebDavEndpoints } from "../../../constant";
 
-const mergedAllowedWebDavEndpoints = [...internalAllowedWebDavEndpoints].filter(
+const mergedAllowedWebDavEndpoints = [...allowedWebDavEndpoints].filter(
   (domain) => Boolean(domain.trim()),
 );
 

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -791,7 +791,7 @@ export const CHAT_PAGE_SIZE = 15;
 export const MAX_RENDER_MSG_COUNT = 45;
 
 // some famous webdav endpoints
-export const internalAllowedWebDavEndpoints = [
+const internalAllowedWebDavEndpoints = [
   "https://dav.jianguoyun.com/dav/",
   "https://dav.dropdav.com/",
   "https://dav.box.com/dav",
@@ -801,6 +801,16 @@ export const internalAllowedWebDavEndpoints = [
   "https://dav.idrivesync.com",
   "https://webdav.yandex.com",
   "https://app.koofr.net/dav/Koofr",
+];
+
+// additional webdav endpoints specified by environment variable
+const whiteWebDavEndpoints = (process.env.WHITE_WEBDAV_ENDPOINTS ?? "")
+  .split(",")
+  .filter((v) => v);
+
+export const allowedWebDavEndpoints = [
+  ...internalAllowedWebDavEndpoints,
+  ...whiteWebDavEndpoints,
 ];
 
 export const DEFAULT_GA_ID = "G-89WN60ZK2E";


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] feat    <!-- 引入新功能 | Introduce new features -->
- [ ] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

<!-- 
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->

本次提交引入了一个新的环境变量 `WHITE_WEBDAV_ENDPOINTS`，允许用户指定额外的受信任的 WebDAV 服务器端点。

在此之前，允许的 WebDAV 端点列表是硬编码的。此更改将内部列表与从新环境变量中提供的、以逗号分隔的用户列表进行合并。

改动包括：
- 修改 `app/constant.ts` 以读取 `WHITE_WEBDAV_ENDPOINTS`，解析它，并导出一个组合的 `allowedWebDavEndpoints` 数组。
- 更新 `app/api/webdav/[...path]/route.ts` 以使用新的 `allowedWebDavEndpoints` 常量，确保自定义端点得到识别和允许。

这为自托管或使用不同 WebDAV 提供商的用户提供了更大的灵活性。

#### 📝 补充信息 | Additional Information

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->
